### PR TITLE
Remove Flake8 and Add Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,15 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.13
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,6 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-      - id: flake8
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ version = "0.0.0"
 dev = [
     # --------- style --------- #
     "black",
+    "ruff",
     "isort",
     # --------- linters --------- #
     "pre-commit", # hooks for applying linters on commit
@@ -67,3 +68,38 @@ skip_glob = [
     "models/*",
     "venv/*",
 ]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 119
+indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ version = "0.0.0"
 dev = [
     # --------- style --------- #
     "black",
-    "flake8",
     "isort",
     # --------- linters --------- #
     "pre-commit", # hooks for applying linters on commit
@@ -68,6 +67,3 @@ skip_glob = [
     "models/*",
     "venv/*",
 ]
-
-[tool.flake8]
-max_line_length = 119


### PR DESCRIPTION
# Description

Remove Flake8 as a linter and add Ruff instead.
The interaction of Flake8 with pyproject.toml is not easy.
Configuring flake would require additional files.

# Type

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Builds
- [ ] CI

# Checklist

- [ ] Code
    - [ ] Title and Description are concise and descriptive.
    - [ ] PR is linked to all related issues.
    - [ ] PR is raised from a correctly named branch.
    - [ ] Target branch is correct.
    - [ ] Commits are squashed if necessary
    - [ ] Commits conform to the guidelines
- [ ] Code Quality
    - [ ] Well written and understandable
    - [ ] Code passes all linting checks
    - [ ] Formatting
    - [ ] Code is not overly complex
- [ ] Quality Assessment
    - [ ] Adequate Unit tests are written
    - [ ] Unit tests are passing
    - [ ] Features work as expected/bug fixes resolve issue
    - [ ] Other means of quality insurance added (if necessary)
- [ ] Documentation
    - [ ] All new features include documentation
    - [ ] README is updated
- [ ] Review
    - [ ] Has been reviewed by author
    - [ ] Has been reviewed by at least one other team member
    - [ ] Merge conflicts with target branch are resolved
- [ ] CI/CD passes all pipeline checks
- [ ] Post Merge
    - [ ] Delete the feature branch (if applicable).
    - [ ] Update related issues or project boards.
