### PR TITLE
elevate permissions of apt get in ci

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -67,8 +67,8 @@ jobs:
           name: cov-html-zip
       - name: Install zip
         run: |
-          apt-get update
-          apt-get install zip -y
+          sudo apt-get update
+          sudo apt-get install zip -y
       - name: Unzip coverage html
         run: unzip coverage_report.zip
       - name: Move into static sphinx dir

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - hotfix/ci-elevate-permissions
 
 jobs:
   coverage_report:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - hotfix/ci-elevate-permissions
 
 jobs:
   coverage_report:
@@ -28,8 +29,8 @@ jobs:
           poetry run pytest test/ --cov=nos --cov-report html:codecov --cov-report json:cov
       - name: Install zip
         run: |
-          apt-get update
-          apt-get install zip -y
+          sudo apt-get update
+          sudo apt-get install zip -y
       - name: package coverage report
         run: |
           zip -r coverage_report.zip codecov


### PR DESCRIPTION
# Description

Currently the pipeline gets a Permission denied when trying to install `zip`. This pr aims to raise the permissions within the pipeline to achieve this install.

# Type

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Builds
- [ ] CI

# Checklist
- [ ] Review
    - [ ] Has been reviewed by author
    - [ ] Has been reviewed by at least one other team member
    - [ ] Merge conflicts with target branch are resolved
- [ ] CI/CD passes all pipeline checks
- [ ] Post Merge
    - [ ] Delete the feature branch (if applicable).
    - [ ] Update related issues or project boards.
